### PR TITLE
Refactor commander CLI options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { Command, Option } from 'commander'
+import { Command, Option, InvalidArgumentError } from 'commander'
 import chalk from 'chalk'
 import fs from 'fs'
 import path from 'path'
@@ -60,20 +60,37 @@ const getInputData = async inputFile => new Promise((resolve, reject) => {
   })
 })
 
+/**
+ * Commander parser that converts a string to an integer.
+ *
+ * @param {string} value - The value from commander.
+ * @param {*} _unused - Unused.
+ * @returns {number} The value parsed as a number.
+ * @throws {InvalidArgumentError} If the arg is not valid.
+ * @see https://github.com/tj/commander.js/wiki/Class:-Option#argparserfn
+ */
+function parseCommanderInt (value, _unused) {
+  const parsedValue = parseInt(value, 10)
+  if (isNaN(parsedValue) || parsedValue < 1) {
+    throw new InvalidArgumentError('Not an positive integer.')
+  }
+  return parsedValue
+}
+
 async function cli () {
   const commander = new Command()
   commander
     .version(pkg.version)
     .addOption(new Option('-t, --theme [theme]', 'Theme of the chart').choices(['default', 'forest', 'dark', 'neutral']).default('default'))
-    .addOption(new Option('-w, --width [width]', 'Width of the page').default(800))
-    .addOption(new Option('-H, --height [height]', 'Height of the page').default(600))
+    .addOption(new Option('-w, --width [width]', 'Width of the page').argParser(parseCommanderInt).default(800))
+    .addOption(new Option('-H, --height [height]', 'Height of the page').argParser(parseCommanderInt).default(600))
     .option('-i, --input <input>', 'Input mermaid file. Files ending in .md will be treated as Markdown and all charts (e.g. ```mermaid (...)```) will be extracted and generated. Required.')
     .option('-o, --output [output]', 'Output file. It should be either md, svg, png or pdf. Optional. Default: input + ".svg"')
     .option('-e, --outputFormat <format>', 'Output format for the generated image. It should be either svg, png or pdf. Optional. Default: output file extension')
     .addOption(new Option('-b, --backgroundColor [backgroundColor]', 'Background color for pngs/svgs (not pdfs). Example: transparent, red, \'#F0F0F0\'.').default('white'))
     .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid.')
     .option('-C, --cssFile [cssFile]', 'CSS file for the page.')
-    .addOption(new Option('-s, --scale [scale]', 'Puppeteer scale factor').default(1))
+    .addOption(new Option('-s, --scale [scale]', 'Puppeteer scale factor').argParser(parseCommanderInt).default(1))
     .option('-f, --pdfFit [pdfFit]', 'Scale PDF to fit chart')
     .option('-q, --quiet', 'Suppress log output')
     .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer.')
@@ -133,18 +150,13 @@ async function cli () {
     myCSS = fs.readFileSync(cssFile, 'utf-8')
   }
 
-  // normalize args
-  width = parseInt(width)
-  height = parseInt(height)
-  const deviceScaleFactor = parseInt(scale || 1, 10)
-
   await run(
     input, output, {
       puppeteerConfig,
       quiet,
       outputFormat,
       parseMMDOptions: {
-        mermaidConfig, backgroundColor, myCSS, pdfFit, viewport: { width, height, deviceScaleFactor }
+        mermaidConfig, backgroundColor, myCSS, pdfFit, viewport: { width, height, deviceScaleFactor: scale }
       }
     }
   )

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ async function cli () {
     .addOption(new Option('-H, --height [height]', 'Height of the page').argParser(parseCommanderInt).default(600))
     .option('-i, --input <input>', 'Input mermaid file. Files ending in .md will be treated as Markdown and all charts (e.g. ```mermaid (...)```) will be extracted and generated. Required.')
     .option('-o, --output [output]', 'Output file. It should be either md, svg, png or pdf. Optional. Default: input + ".svg"')
-    .option('-e, --outputFormat <format>', 'Output format for the generated image. It should be either svg, png or pdf. Optional. Default: output file extension')
+    .addOption(new Option('-e, --outputFormat [format]', 'Output format for the generated image.').choices(['svg', 'png', 'pdf']).default(null, 'Loaded from the output file extension'))
     .addOption(new Option('-b, --backgroundColor [backgroundColor]', 'Background color for pngs/svgs (not pdfs). Example: transparent, red, \'#F0F0F0\'.').default('white'))
     .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid.')
     .option('-C, --cssFile [cssFile]', 'CSS file for the page.')

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import chalk from 'chalk'
 import fs from 'fs'
 import path from 'path'
@@ -64,19 +64,19 @@ async function cli () {
   const commander = new Command()
   commander
     .version(pkg.version)
-    .option('-t, --theme [theme]', 'Theme of the chart, could be default, forest, dark or neutral. Optional. Default: default', /^default|forest|dark|neutral$/, 'default')
-    .option('-w, --width [width]', 'Width of the page. Optional. Default: 800', /^\d+$/, '800')
-    .option('-H, --height [height]', 'Height of the page. Optional. Default: 600', /^\d+$/, '600')
+    .addOption(new Option('-t, --theme [theme]', 'Theme of the chart').choices(['default', 'forest', 'dark', 'neutral']).default('default'))
+    .addOption(new Option('-w, --width [width]', 'Width of the page').default(800))
+    .addOption(new Option('-H, --height [height]', 'Height of the page').default(600))
     .option('-i, --input <input>', 'Input mermaid file. Files ending in .md will be treated as Markdown and all charts (e.g. ```mermaid (...)```) will be extracted and generated. Required.')
     .option('-o, --output [output]', 'Output file. It should be either md, svg, png or pdf. Optional. Default: input + ".svg"')
     .option('-e, --outputFormat <format>', 'Output format for the generated image. It should be either svg, png or pdf. Optional. Default: output file extension')
-    .option('-b, --backgroundColor [backgroundColor]', 'Background color for pngs/svgs (not pdfs). Example: transparent, red, \'#F0F0F0\'. Optional. Default: white')
-    .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid. Optional')
-    .option('-C, --cssFile [cssFile]', 'CSS file for the page. Optional')
-    .option('-s, --scale [scale]', 'Puppeteer scale factor, default 1. Optional')
+    .addOption(new Option('-b, --backgroundColor [backgroundColor]', 'Background color for pngs/svgs (not pdfs). Example: transparent, red, \'#F0F0F0\'.').default('white'))
+    .option('-c, --configFile [configFile]', 'JSON configuration file for mermaid.')
+    .option('-C, --cssFile [cssFile]', 'CSS file for the page.')
+    .addOption(new Option('-s, --scale [scale]', 'Puppeteer scale factor').default(1))
     .option('-f, --pdfFit [pdfFit]', 'Scale PDF to fit chart')
     .option('-q, --quiet', 'Suppress log output')
-    .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer. Optional')
+    .option('-p --puppeteerConfigFile [puppeteerConfigFile]', 'JSON configuration file for puppeteer.')
     .parse(process.argv)
 
   const options = commander.opts()
@@ -136,7 +136,6 @@ async function cli () {
   // normalize args
   width = parseInt(width)
   height = parseInt(height)
-  backgroundColor = backgroundColor || 'white'
   const deviceScaleFactor = parseInt(scale || 1, 10)
 
   await run(


### PR DESCRIPTION
> warning:
> This PR is currently only for this fork for testing CI

## :bookmark_tabs: Summary

Removes commander deprecated arguments, and removes duplicate ```default: 800 (default: 800)` --help text```.

## :straight_ruler: Design Decisions

Using regex in Commander directly is deprecated since Command v7, see https://github.com/tj/commander.js/blob/82fcb98cc27164a98e0c5f2c6f54621b5bbceef9/typings/index.d.ts#L540-L541

Instead, I've replaced it with a custom function that checks whether the input variables are integers.

#### `--help` before

```console
alois@me:~/Documents/mermaid-cli (master)$ ./src/cli.js --help
Usage: cli [options]

Options:
  -V, --version                                   output the version number
  -t, --theme [theme]                             Theme of the chart, could be default, forest, dark or neutral.
                                                  Optional. Default: default (default: "default")
  -w, --width [width]                             Width of the page. Optional. Default: 800 (default: "800")
  -H, --height [height]                           Height of the page. Optional. Default: 600 (default: "600")
  -i, --input <input>                             Input mermaid file. Files ending in .md will be treated as Markdown
                                                  and all charts (e.g. ```mermaid (...)```) will be extracted and
                                                  generated. Required.
  -o, --output [output]                           Output file. It should be either md, svg, png or pdf. Optional.
                                                  Default: input + ".svg"
  -e, --outputFormat <format>                     Output format for the generated image. It should be either svg, png
                                                  or pdf. Optional. Default: output file extension
  -b, --backgroundColor [backgroundColor]         Background color for pngs/svgs (not pdfs). Example: transparent, red,
                                                  '#F0F0F0'. Optional. Default: white
  -c, --configFile [configFile]                   JSON configuration file for mermaid. Optional
  -C, --cssFile [cssFile]                         CSS file for the page. Optional
  -s, --scale [scale]                             Puppeteer scale factor, default 1. Optional
  -f, --pdfFit [pdfFit]                           Scale PDF to fit chart
  -q, --quiet                                     Suppress log output
  -p --puppeteerConfigFile [puppeteerConfigFile]  JSON configuration file for puppeteer. Optional
  -h, --help                                      display help for command
```

#### `--help` after

```console
alois@me:~/Documents/mermaid-cli (master)$ ./src/cli.js --help
Usage: cli [options]

Options:
  -V, --version                                   output the version number
  -t, --theme [theme]                             Theme of the chart (choices: "default", "forest", "dark", "neutral",
                                                  default: "default")
  -w, --width [width]                             Width of the page (default: 800)
  -H, --height [height]                           Height of the page (default: 600)
  -i, --input <input>                             Input mermaid file. Files ending in .md will be treated as Markdown
                                                  and all charts (e.g. ```mermaid (...)```) will be extracted and
                                                  generated. Required.
  -o, --output [output]                           Output file. It should be either md, svg, png or pdf. Optional.
                                                  Default: input + ".svg"
  -e, --outputFormat [format]                     Output format for the generated image. (choices: "svg", "png", "pdf",
                                                  default: Loaded from the output file extension)
  -b, --backgroundColor [backgroundColor]         Background color for pngs/svgs (not pdfs). Example: transparent, red,
                                                  '#F0F0F0'. (default: "white")
  -c, --configFile [configFile]                   JSON configuration file for mermaid.
  -C, --cssFile [cssFile]                         CSS file for the page.
  -s, --scale [scale]                             Puppeteer scale factor (default: 1)
  -f, --pdfFit [pdfFit]                           Scale PDF to fit chart
  -q, --quiet                                     Suppress log output
  -p --puppeteerConfigFile [puppeteerConfigFile]  JSON configuration file for puppeteer.
  -h, --help                                      display help for command
```

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
