### PR TITLE
test: add a test case for inline `%%init%%`

### DIFF
--- a/test-positive/custom-init-config.mmd
+++ b/test-positive/custom-init-config.mmd
@@ -1,0 +1,17 @@
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ff0000'}}}%%
+%% Example taken from https://mermaid-js.github.io/mermaid/#/./theming?id=customizing-themes-with-themevariables
+graph TD
+    A[Christmas] -->|Get money| B(Go shopping)
+    B --> C{Let me think}
+    B --> G[/Another/]
+    C ==>|One| D[Laptop]
+    C -->|Two| E[iPhone]
+    %% Uses font-awesome for the car icon here
+    C -->|Three| F[fa:fa-car Car]
+    subgraph section
+    C
+    D
+    E
+    F
+    G
+    end


### PR DESCRIPTION
> **Warning**
>
> This PR is in a fork for testing GitHub Actions

## :bookmark_tabs: Summary

Adds a test case for the `%%init%%` operator.
This test also uses a font-awesome symbol, so it tests for that too.

Still todo in the future is the add a `--config` test

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid-cli/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
